### PR TITLE
Make jms and amqp connectors optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
             <artifactId>mule-jms-connector</artifactId>
             <version>1.9.7</version>
             <classifier>mule-plugin</classifier>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.connectors</groupId>
@@ -119,6 +120,7 @@
             <artifactId>mule-amqp-connector</artifactId>
             <version>1.8.1</version>
             <classifier>mule-plugin</classifier>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.mulesoft.muleesb.modules</groupId>
@@ -155,8 +157,8 @@
         <connection>scm:git:git@github.com:anypointcloud/json-logger.git</connection>
         <developerConnection>scm:git:git@github.com:anypointcloud/json-logger.git</developerConnection>
         <url>https://github.com/anypointcloud/json-logger</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <repositories>
         <repository>


### PR DESCRIPTION
If you are not using JMS or AMQ for logging, this update makes the dependencies optional (you will have to add them explicitly if you need them), reducing the size of the resulting application by about 10 MB.