### PR TITLE
[RELEASE] downgrade gpg plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.8</version>
+                        <version>3.1.0</version>
                         <configuration>
                             <gpgArguments>
                                 <arg>--pinentry-mode</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,12 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>3.2.8</version>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -83,21 +83,7 @@
                     <runtimeProduct>MULE_EE</runtimeProduct>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>build
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+       </plugins>
     </build>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
                     <runtimeProduct>MULE_EE</runtimeProduct>
                 </configuration>
             </plugin>
-       </plugins>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,20 @@
                     <runtimeProduct>MULE_EE</runtimeProduct>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>build
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
known issue with 3.2.8, use 3.1.0 which has been tested in the redis connector