### PR TITLE
Fix GPG signing in GitHub Actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,13 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.8</version>
+                        <version>3.1.0</version>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
- Downgrade maven-gpg-plugin from 3.2.8 to 3.1.0
- Add pinentry-mode loopback configuration
- Resolves MGPG-112: version 3.2.0+ has issues with non-interactive signing