### PR TITLE
Fix GPG signing with environment variable

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -40,4 +40,4 @@ jobs:
     - name: Run Maven Release
       run: mvn -Prelease-sign-artifacts -DskipTests -Darguments=-DskipTests release:prepare release:perform -B
       env:
-        GPG_TTY: $(tty)
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Summary
- Fix GPG signing in GitHub Actions by using MAVEN_GPG_PASSPHRASE environment variable
- Based on solution from https://github.com/actions/setup-java/issues/668

## Changes
- Update GitHub Actions workflow to pass GPG passphrase as MAVEN_GPG_PASSPHRASE environment variable
- Keep maven-gpg-plugin at version 3.2.8 (no configuration needed)

## Test plan
- [ ] GitHub Actions workflow runs successfully with GPG signing

## References
- Issue: https://github.com/actions/setup-java/issues/668
- POC: https://github.com/loesak/github-setupjava-issue-668-poc