### PR TITLE
Configure release tags to use v prefix

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -45,6 +45,6 @@ jobs:
         gpg: true
 
     - name: Run Maven Release
-      run: mvn -Prelease-sign-artifacts -DskipTests -Darguments=-DskipTests release:prepare release:perform -B
+      run: mvn -Prelease-sign-artifacts -DskipTests -Darguments=-DskipTests -DtagNameFormat="v@{project.version}" release:prepare release:perform -B
       env:
         MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Summary
Configure maven-release-plugin to create tags with `v` prefix (e.g., `v3.0.2` instead of `json-logger-3.0.2`)

## Changes
- Add `-DtagNameFormat="v@{project.version}"` parameter to maven release command
- Follows common semantic versioning tag format used by most projects

## Note
The existing `json-logger-3.0.1` tag has already been renamed to `v3.0.1` manually.