### PR TITLE
Apply some hardening to build.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  
+  # Maintain dependencies for Maven
+  - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+
     - name: maven-settings-action
-      uses: s4u/maven-settings-action@v3.1.0
+      uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # commit hash references to v4.0.0
       with:
-        servers: '[{"id": "mulesoft-ee-releases", "username": "${{ secrets.MULE_REPO_USER }}", "password": "${{ secrets.MULE_REPO_PASSWORD }}"}]'
+        servers: '[{"id": "mulesoft-ee-releases", "username": "${env.MULE_REPO_USER}", "password": "${env.MULE_REPO_PASSWORD }"}]'
         repositories: '[{"id": "mulesoft-ee-releases", "name": "MuleSoft EE Releases", "url": "https://repository.mulesoft.org/nexus-ee/content/repositories/releases-ee/"}]'
+
     - name: Build and test
+      env:
+        MULE_REPO_USER: ${{ secrets.MULE_REPO_USER }}
+        MULE_REPO_PASSWORD: ${{ secrets.MULE_REPO_PASSWORD }}
       run: mvn -B verify


### PR DESCRIPTION
Hi @mtransier,
I have applied some hardening to build.yml:
- reference non `actions/*` actions via commit hash instead of version
- avoid storing credentials on file system, otherwise every step in a workflow file has access to it

Also added a dependabot.yml, so one can also see PRs when new Github actions are available.

When PR build is green, I could also update the maven-release.yml.