### PR TITLE
JsonloggerConfiguration now registers itself with the LogEventSingleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.iml
 *.iws
  
+# ACB
+.vscode/
+
 # Mac
 .DS_Store
  

--- a/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerConfiguration.java
+++ b/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerConfiguration.java
@@ -3,6 +3,7 @@ package org.mule.extension.jsonlogger.internal;
 import org.mule.extension.jsonlogger.api.pojos.LoggerConfig;
 import org.mule.extension.jsonlogger.internal.destinations.Destination;
 import org.mule.extension.jsonlogger.internal.singleton.ConfigsSingleton;
+import org.mule.extension.jsonlogger.internal.singleton.LogEventSingleton;
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.lifecycle.Initialisable;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -25,6 +26,9 @@ public class JsonloggerConfiguration extends LoggerConfig implements Initialisab
     @Inject
     ConfigsSingleton configsSingleton;
 
+    @Inject
+    LogEventSingleton logEventSingleton;
+    
     @RefName
     private String configName;
 
@@ -73,6 +77,7 @@ public class JsonloggerConfiguration extends LoggerConfig implements Initialisab
             this.externalDestination.initialise();
         }
         configsSingleton.addConfig(configName, this); // Should be refactored once SDK supports passing configs to Scopes
+        logEventSingleton.addDestinationForConfig(this);
     }
 
     @Override

--- a/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerConfiguration.java
+++ b/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerConfiguration.java
@@ -85,5 +85,7 @@ public class JsonloggerConfiguration extends LoggerConfig implements Initialisab
         if (this.externalDestination != null) {
             this.externalDestination.dispose();
         }
+        logEventSingleton.removeDestinationForConfig(this);
+        configsSingleton.removeConfig(configName);
     }
 }

--- a/src/main/java/org/mule/extension/jsonlogger/internal/destinations/events/LogEventHandler.java
+++ b/src/main/java/org/mule/extension/jsonlogger/internal/destinations/events/LogEventHandler.java
@@ -9,15 +9,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 
 public class LogEventHandler implements EventHandler<LogEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LogEventHandler.class);
 
     private Map<String,List<String>> aggregatedLogsPerConfig = new HashMap<String, List<String>>();
-    private Map<String, Destination> destinations = new HashMap<String, Destination>();
+    private ConcurrentMap<String, Destination> destinations;
 
-    public LogEventHandler (Map<String, Destination> destinations) {
+    public LogEventHandler(ConcurrentMap<String, Destination> destinations) {
         this.destinations = destinations;
     }
 

--- a/src/main/java/org/mule/extension/jsonlogger/internal/singleton/ConfigsSingleton.java
+++ b/src/main/java/org/mule/extension/jsonlogger/internal/singleton/ConfigsSingleton.java
@@ -3,8 +3,8 @@ package org.mule.extension.jsonlogger.internal.singleton;
 import org.mule.extension.jsonlogger.internal.JsonloggerConfiguration;
 import org.mule.runtime.api.artifact.Registry;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
 
@@ -13,7 +13,7 @@ public class ConfigsSingleton {
     @Inject
     private Registry registry;
     
-    private Map<String, JsonloggerConfiguration> configs = new HashMap<String, JsonloggerConfiguration>();
+    private Map<String, JsonloggerConfiguration> configs = new ConcurrentHashMap<String, JsonloggerConfiguration>();
 
     public JsonloggerConfiguration getConfig(String configName) {
         JsonloggerConfiguration config = configs.get(configName);
@@ -28,4 +28,7 @@ public class ConfigsSingleton {
         this.configs.put(configName, config);
     }
 
+    public void removeConfig(String configName) {
+        this.configs.remove(configName);
+    }
 }

--- a/src/main/java/org/mule/extension/jsonlogger/internal/singleton/ConfigsSingleton.java
+++ b/src/main/java/org/mule/extension/jsonlogger/internal/singleton/ConfigsSingleton.java
@@ -1,20 +1,27 @@
 package org.mule.extension.jsonlogger.internal.singleton;
 
 import org.mule.extension.jsonlogger.internal.JsonloggerConfiguration;
+import org.mule.runtime.api.artifact.Registry;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Inject;
+
 public class ConfigsSingleton {
 
+    @Inject
+    private Registry registry;
+    
     private Map<String, JsonloggerConfiguration> configs = new HashMap<String, JsonloggerConfiguration>();
 
-    public Map<String, JsonloggerConfiguration> getConfigs() {
-        return configs;
-    }
-
     public JsonloggerConfiguration getConfig(String configName) {
-        return this.configs.get(configName);
+        JsonloggerConfiguration config = configs.get(configName);
+        if (config == null) {
+            registry.lookupByName(configName);
+            config = configs.get(configName);
+        }
+        return config;
     }
 
     public void addConfig(String configName, JsonloggerConfiguration config) {

--- a/src/main/java/org/mule/extension/jsonlogger/internal/singleton/LogEventSingleton.java
+++ b/src/main/java/org/mule/extension/jsonlogger/internal/singleton/LogEventSingleton.java
@@ -6,17 +6,18 @@ import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
 import com.lmax.disruptor.util.DaemonThreadFactory;
+
+import org.mule.extension.jsonlogger.internal.JsonloggerConfiguration;
 import org.mule.extension.jsonlogger.internal.destinations.Destination;
 import org.mule.extension.jsonlogger.internal.destinations.events.LogEvent;
 import org.mule.extension.jsonlogger.internal.destinations.events.LogEventHandler;
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.lifecycle.Initialisable;
-import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 public class LogEventSingleton implements Initialisable, Disposable {
@@ -28,10 +29,7 @@ public class LogEventSingleton implements Initialisable, Disposable {
     // Specify the event wait timeout in milliseconds before dropping the events
     private final Integer WAIT_TIMEOUT = Integer.valueOf(System.getProperty("json.logger.destinations.waittimeout", "100"));
 
-    @Inject
-    ConfigsSingleton configs;
-
-    private HashMap<String, Destination> destinations = new HashMap<String, Destination>();
+    private ConcurrentMap<String, Destination> destinations = new ConcurrentHashMap<String, Destination>();
 
     // Construct the Disruptor
     private Disruptor<LogEvent> disruptor;
@@ -43,12 +41,12 @@ public class LogEventSingleton implements Initialisable, Disposable {
     }
 
     public void publishToExternalDestination(String correlationId, String finalLog, String configName) {
-        LOGGER.debug("Publishing event to ringBuffer for destination type: " + this.destinations.get(configName).getSelectedDestinationType());
+        LOGGER.debug("Publishing event to ringBuffer for config: " + configName);
         ringBuffer.publishEvent(LogEventSingleton::translate, correlationId, finalLog, configName);
     }
 
     @Override
-    public void initialise() throws InitialisationException {
+    public void initialise() {
         LOGGER.debug("Init LogEventSingleton...");
 
         // Define waitStrategy: LiteTimeoutBlockingWaitStrategy avoids "blocking wait" but may cause LogEvent loss
@@ -57,10 +55,6 @@ public class LogEventSingleton implements Initialisable, Disposable {
         // Init disruptor ring buffer
         this.disruptor  = new Disruptor<>(LogEvent::new, BUFFER_SIZE, DaemonThreadFactory.INSTANCE, ProducerType.SINGLE, waitStrategy);
 
-        // Load external destinations
-        configs.getConfigs().forEach(
-                (configName, config) -> this.destinations.put(configName, config.getExternalDestination())
-        );
         this.logEventHandler = new LogEventHandler(this.destinations);
         // Connect the handler with initialized list of destinations
         disruptor.handleEventsWith(logEventHandler);
@@ -70,6 +64,12 @@ public class LogEventSingleton implements Initialisable, Disposable {
 
         // Get the ring buffer from the Disruptor to be used for publishing.
         this.ringBuffer = disruptor.getRingBuffer();
+    }
+    
+    public void addDestinationForConfig(JsonloggerConfiguration config) {
+        if (config.getExternalDestination() != null) {        
+            this.destinations.put(config.getConfigName(), config.getExternalDestination());
+        }
     }
 
     @Override

--- a/src/main/java/org/mule/extension/jsonlogger/internal/singleton/LogEventSingleton.java
+++ b/src/main/java/org/mule/extension/jsonlogger/internal/singleton/LogEventSingleton.java
@@ -77,4 +77,8 @@ public class LogEventSingleton implements Initialisable, Disposable {
         this.disruptor.shutdown();
         this.logEventHandler.flushAllLogs();
     }
+
+    public void removeDestinationForConfig(JsonloggerConfiguration jsonloggerConfiguration) {
+        this.destinations.remove(jsonloggerConfiguration.getConfigName());
+    }
 }

--- a/src/test/munit/json-logger-test-suite.xml
+++ b/src/test/munit/json-logger-test-suite.xml
@@ -14,7 +14,7 @@
 
     <munit:config name="json-logger-test-suite.xml" />
 
-    <munit:test description="Test" doc:id="5b060d47-d4cf-49c5-8ab1-1be81eeccbcf"
+    <munit:test description="Test Logger" doc:id="5b060d47-d4cf-49c5-8ab1-1be81eeccbcf"
         name="json-logger-test-suite-test-logger-test">
         <munit:execution>
             <flow-ref doc:id="5cf7e93b-6cb6-441f-9b6c-8b8e96a8ad62" doc:name="test-logger" name="test-logger" />
@@ -30,4 +30,19 @@
         </munit:validation>
     </munit:test>
 
+    <munit:test description="Test Logger Scope" doc:id="e2cdfdcf-0c23-4179-9b80-9ab62987ed0c"
+        name="json-logger-test-suite-test-logger-scope-test">
+        <munit:execution>
+            <flow-ref doc:id="a651a767-0d62-41cf-8906-9708b6398172" doc:name="test-logger-scope" name="test-logger-scope" />
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:verify-call doc:id="b58a1678-8048-43b8-84f4-7298d3ada551"
+                doc:name="Set Payload" processor="set-payload">
+                <munit-tools:with-attributes>
+                    <munit-tools:with-attribute attributeName="doc:id"
+                        whereValue="77f6a482-dff5-4d24-8da8-c056decd7fbf" />
+                </munit-tools:with-attributes>
+            </munit-tools:verify-call>
+        </munit:validation>
+    </munit:test>
 </mule>

--- a/src/test/resources/test-mule-config.xml
+++ b/src/test/resources/test-mule-config.xml
@@ -1,28 +1,32 @@
-<mule
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
     xmlns:json-logger="http://www.mulesoft.org/schema/mule/json-logger"
-    xmlns="http://www.mulesoft.org/schema/mule/core"
     xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
         http://www.mulesoft.org/schema/mule/json-logger http://www.mulesoft.org/schema/mule/json-logger/current/mule-json-logger.xsd">
 
-    <json-logger:config name="JSON_Logger_Config"
-        doc:name="JSON Logger Config"
-        doc:id="d3c3b8c7-8417-4545-9e60-9c914261d272"
+    <json-logger:config name="JSON_Logger_Config" doc:name="JSON Logger Config" doc:id="d3c3b8c7-8417-4545-9e60-9c914261d272"
         environment="MUnit" />
-    <configuration-properties
-        file="json-logger.properties" />
 
-    <flow name="test-logger"
-        doc:id="457201a2-e5c5-4ac6-ab29-ab63bc517a7b">
-        <set-payload
-            value='#[output application/json --- [{"A": 1, "B": 1}, {"A": 2}]]'
-            doc:name="Test"
-            doc:id="7941661a-16da-4271-9657-1d9580ab4c77" />
+    <configuration-properties file="json-logger.properties" />
+
+    <flow name="test-logger" doc:id="457201a2-e5c5-4ac6-ab29-ab63bc517a7b">
+        <set-payload doc:name="Test" doc:id="df5423e2-0921-4b6f-97e4-4242aecc9488"
+            value='#[output application/json --- [{"A": 1, "B": 1}, {"A": 2}]]' />
         <json-logger:logger doc:name="Logger" doc:id="8909da6b-5806-4001-a9d4-6593ee473743"
-            message="another dummy" config-ref="JSON_Logger_Config" tracePoint="FLOW">
-        </json-logger:logger>
-        <set-payload value="all good" doc:name="all good" doc:id="89ac164e-c37f-4b11-ad47-e30f4be9f09a" />
+            message="another dummy" config-ref="JSON_Logger_Config" tracePoint="FLOW" />
+        <set-payload doc:name="all good" doc:id="89ac164e-c37f-4b11-ad47-e30f4be9f09a"
+            value="all good" />
     </flow>
 
+    <flow name="test-logger-scope" doc:id="3666b578-903c-430a-afec-9f787913cce0">
+        <json-logger:logger-scope doc:name="Logger scope" doc:id="a1b5a1a7-de75-4981-a4e6-4b079ac813fc"
+            configurationRef="JSON_Logger_Config" scopeTracePoint="DATA_TRANSFORM_SCOPE">
+            <set-payload doc:name="Test" doc:id="a2fd4c85-51db-4fd6-9e04-4b4fb2804c8d"
+                value='#[output application/json --- [{"A": 1, "B": 1}, {"A": 2}]]' />
+        </json-logger:logger-scope>
+        <set-payload doc:name="all good" doc:id="77f6a482-dff5-4d24-8da8-c056decd7fbf"
+            value="all good" />
+    </flow>
 </mule>


### PR DESCRIPTION
Previously, the LogEventSingleton used the ConfigsSingleton to read all existing JsonloggerConfigurations on startup, which could lead to missing some configurations when running MUnits.