### PR TITLE
Add audit routing classification and Mule 4.9 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,23 @@ Improvements:
 * Minimized dependency footprint (down from ~23MB to ~13MB)
 * Optimized parsing of TypedValue content fields
 
+## Audit log routing
+
+Both the logger and logger scope operations expose a `logType` input. It defaults to
+`APPLICATION`, so existing configurations remain valid. Set it to `AUDIT` for records
+that the downstream logging pipeline should route to an audit destination:
+
+```xml
+<json-logger:logger
+    config-ref="JSON_Logger_Config"
+    message="Invoice synchronization completed"
+    priority="INFO"
+    logType="AUDIT" />
+```
+
+The emitted JSON contains `"logType":"AUDIT"`. `logType` is intentionally separate
+from `priority`; audit records retain normal Log4j severity and filtering behavior.
+
 ## Authors
 
 * **Andres Ramirez** [Email: andres.ramirez@mulesoft.com] (original version)

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>cloud.anypoint</groupId>
+    <groupId>f8deffbe-23c6-4edd-a7f4-38cfb0f52e35</groupId>
     <artifactId>json-logger</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>JSON Logger</name>
 
@@ -30,6 +30,7 @@
     <properties>
         <munit.extensions.maven.plugin.version>1.6.0</munit.extensions.maven.plugin.version>
         <munit.version>3.5.0</munit.version>
+        <exchange.mule.maven.plugin.version>0.0.23</exchange.mule.maven.plugin.version>
     </properties>
 
     <developers>
@@ -84,6 +85,27 @@
                     <runtimeProduct>MULE_EE</runtimeProduct>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.mule.tools.maven</groupId>
+                <artifactId>exchange-mule-maven-plugin</artifactId>
+                <version>${exchange.mule.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exchange-pre-deploy</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>exchange-deploy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -130,6 +152,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.mule.connectors</groupId>
@@ -236,4 +263,13 @@
             </build>
         </profile>
     </profiles>
+
+    <distributionManagement>
+        <repository>
+            <id>anypoint-exchange-v3</id>
+            <name>Anypoint Exchange V3</name>
+            <url>https://maven.anypoint.mulesoft.com/api/v3/organizations/${project.groupId}/maven</url>
+            <layout>default</layout>
+        </repository>
+    </distributionManagement>
 </project>

--- a/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerOperations.java
+++ b/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerOperations.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.mule.extension.jsonlogger.api.pojos.LoggerProcessor;
+import org.mule.extension.jsonlogger.api.pojos.LogType;
 import org.mule.extension.jsonlogger.api.pojos.Priority;
 import org.mule.extension.jsonlogger.api.pojos.ScopeTracePoint;
 import org.mule.extension.jsonlogger.internal.datamask.JsonMasker;
@@ -250,6 +251,7 @@ public class JsonloggerOperations {
     @MediaType("application/json")
     public void loggerScope(@DisplayName("Module configuration") @Example("JSON_Logger_Config") @Summary("Indicate which Global config should be associated with this Scope.") String configurationRef,
                             @Optional(defaultValue="INFO") Priority priority,
+                            @Optional(defaultValue="APPLICATION") @Summary("Classifies the log entry for downstream routing") LogType logType,
                             @Optional(defaultValue="OUTBOUND_REQUEST_SCOPE") ScopeTracePoint scopeTracePoint,
                             @Optional @Summary("If not set, by default will log to the org.mule.extension.jsonlogger.JsonLogger category") String category,
                             @Optional(defaultValue="#[correlationId]") @Placement(tab = "Advanced") String correlationId,
@@ -304,6 +306,7 @@ public class JsonloggerOperations {
             loggerProcessor.put("correlationId", correlationId);
             loggerProcessor.put("tracePoint", scopeTracePoint.toString() + "_BEFORE");
             loggerProcessor.put("priority", priority.toString());
+            loggerProcessor.put("logType", logType.toString());
             loggerProcessor.put("elapsed", elapsed);
             loggerProcessor.put("scopeElapsed", 0);
             if (configs.getConfig(configurationRef).getJsonOutput().isLogLocationInfo()) {

--- a/src/main/resources/schema/loggerProcessor.json
+++ b/src/main/resources/schema/loggerProcessor.json
@@ -64,6 +64,18 @@
       },
       "note": "This field is mandatory. DON'T REMOVE"
     },
+    "logType": {
+      "type": "string",
+      "javaType": "org.mule.extension.jsonlogger.api.pojos.LogType",
+      "enum": [
+        "APPLICATION",
+        "AUDIT"
+      ],
+      "sdk": {
+        "default": "APPLICATION",
+        "summary": "Classifies the log entry for downstream routing"
+      }
+    },
     "category": {
       "type": "string",
       "sdk": {

--- a/src/test/resources/test-mule-config.xml
+++ b/src/test/resources/test-mule-config.xml
@@ -20,7 +20,7 @@
             doc:name="Test"
             doc:id="7941661a-16da-4271-9657-1d9580ab4c77" />
         <json-logger:logger doc:name="Logger" doc:id="8909da6b-5806-4001-a9d4-6593ee473743"
-            message="another dummy" config-ref="JSON_Logger_Config" tracePoint="FLOW">
+            message="another dummy" config-ref="JSON_Logger_Config" tracePoint="FLOW" logType="AUDIT">
         </json-logger:logger>
         <set-payload value="all good" doc:name="all good" doc:id="89ac164e-c37f-4b11-ad47-e30f4be9f09a" />
     </flow>


### PR DESCRIPTION
## Summary
- add an optional logType input with APPLICATION and AUDIT values
- emit logType from logger and logger-scope operations for downstream routing
- declare Commons IO directly so Mule 4.9/MUnit plugin discovery can load logger classes
- add Exchange publication configuration for the Figma-owned build

## Validation
- mvn clean test

## Notes
logType defaults to APPLICATION, so existing logger configurations remain valid. Audit entries retain their normal Log4j priority; the logging pipeline can route records whose logType is AUDIT to DynamoDB.